### PR TITLE
fix: QR code size on Android devices

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -185,7 +185,7 @@
       >.qr-image {
         width: 100%;
 
-        >img {
+        >img, >canvas {
           width: 100%;
           height: auto;
         }


### PR DESCRIPTION
Caused by https://github.com/davidshimjs/qrcodejs/issues/287.

On Android, the canvas will have the QR code and the img is empty. On browsers/iOS the canvas  contains the QR code and the img is empty.