### PR TITLE
Add support for virtual buttons

### DIFF
--- a/lib/MatterBridgeServer.mjs
+++ b/lib/MatterBridgeServer.mjs
@@ -1181,6 +1181,71 @@ export default class MatterBridgeServer {
 
           break;
         }
+
+        case 'button': {
+          if (device.capabilitiesObj?.button) {
+            class HomeyButtonServer extends OnOffServer {
+              async on() {
+                await device.setCapabilityValue({
+                  capabilityId: 'button',
+                  value: true,
+                });
+
+                setTimeout(async () => {
+                  await endpoint
+                    .set({
+                      onOff: {
+                        onOff: false,
+                      },
+                    })
+                    .catch((err) =>
+                      this.debug(
+                        `Error resetting button state for device ${device.id}: ${err.message}`,
+                      ),
+                    );
+                }, 100);
+              }
+
+              async off() {
+              }
+            }
+
+            const endpoint = new Endpoint(
+              OnOffPlugInUnitDevice.with(HomeyButtonServer),
+              {
+                id: 'main',
+                onOff: {
+                  onOff: false,
+                },
+              },
+            );
+            await deviceEndpoint.add(endpoint);
+
+            makeCapabilityInstance('button', async () => {
+              await endpoint.set({
+                onOff: {
+                  onOff: true,
+                },
+              });
+
+              setTimeout(async () => {
+                await endpoint
+                  .set({
+                    onOff: {
+                      onOff: false,
+                    },
+                  })
+                  .catch((err) =>
+                    this.debug(
+                      `Error resetting button state for device ${device.id}: ${err.message}`,
+                    ),
+                  );
+              }, 100);
+            });
+          }
+
+          break;
+        }
         default: {
           // If the device has an onoff capability, add it as an OnOffPlugInUnitDevice.
           if (device.capabilitiesObj?.onoff) {


### PR DESCRIPTION
This PR adds support for virtual buttons, for example, to trigger a Homey Flow.

--

I do want to highlight some missing parts on the tooling side (eg. no eslint/typescript).

For a first party app I would expect a stronger baseline for code quality. Many developers will look at this project to understand how a Homey app should be structured, so having proper linting and TypeScript support sets the right example and helps contributors work more efficiently.

Happy to follow up this PR with adding eslint if you want 👍 